### PR TITLE
Adds support for nested key properties

### DIFF
--- a/can-map-compat-test.js
+++ b/can-map-compat-test.js
@@ -14,6 +14,14 @@ function tests(typeName, createType) {
 		QUnit.equal(val, "bar", "get the value");
 	});
 
+	QUnit.test("map.attr() supports nested value", function() {
+		var Type = makeCompat(createType());
+		var map = new Type({ parent: { child: 1 }});
+
+		var val = map.attr("parent.child");
+		QUnit.equal(val, 1, "Got a nested prop");
+	});
+
 	QUnit.test("map.attr() gets unwrapped version", function() {
 		var Type = makeCompat(createType());
 		var map = new Type({ foo: "bar", baz: "qux"});
@@ -46,6 +54,14 @@ function tests(typeName, createType) {
 
 		var val = map.attr("foo", "baz").attr("foo");
 		QUnit.equal(val, "baz", "value changed");
+	});
+
+	QUnit.test("map.attr(key, value) supports nested objects", function() {
+		var Type = makeCompat(createType());
+		var map  = new Type({ parent: { child: 1 }});
+
+		var val = map.attr("parent.child", 2).attr("parent.child");
+		QUnit.equal(val, 2, "Able to set nested values");
 	});
 
 	QUnit.module('can-map-compat - ' + typeName + ' .removeAttr()');

--- a/can-map-compat.js
+++ b/can-map-compat.js
@@ -1,3 +1,4 @@
+var canKey = require("can-key");
 var canReflect = require("can-reflect");
 var canLog = require("can-log");
 
@@ -36,11 +37,11 @@ function makeCompat(Type, enableWarning) {
 		}
 		// map.attr(key)
 		else if(argsLen === 1) {
-			return canReflect.getKeyValue(this, key);
+			return canKey.get(this, key);
 		}
 		// map.attr(key, val)
 		else {
-			canReflect.setKeyValue(this, key, value);
+			canKey.set(this, key, value);
 			return this;
 		}
 	};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "can-key": "^1.2.0",
     "can-log": "^1.0.0",
     "can-reflect": "^1.17.4"
   }


### PR DESCRIPTION
This adds support for getting/setting nested key values. This allows
these to work:

```js
let map = new MapType({ parent: { child: 1 } });

console.log(map.attr("parent.child")); // -> 1

map.attr("parent.child", 2);
console.log(map.attr("parent.child")); // -> 2
```

Closes #2